### PR TITLE
Tcp push

### DIFF
--- a/gui/sdl/viewer.h
+++ b/gui/sdl/viewer.h
@@ -52,7 +52,7 @@ class Viewer {
   void RenderSurface(const DisplayPartialBitmap* partial);
   void RenderCursor(const DisplayMouseCursor* cursor_update);
   void HandleEvent(const SDL_Event& event);
-  void HandleSpeicalKey(const SDL_Keysym& keysym);
+  void RegisterKeyboardShortcuts();
   PointerInputInterface* GetActivePointer();
   void SendPointerEvent();
   void SendResizerEvent();
@@ -89,6 +89,7 @@ class Viewer {
 
   bool pcm_playback_error_ = false;
   snd_pcm_t* pcm_playback_ = nullptr;
+  std::unordered_map<int, VoidCallback> keyboard_shortcuts_;
 };
 
 #endif // _MVISOR_VIEWER_H

--- a/networks/uip/map_tcp.cc
+++ b/networks/uip/map_tcp.cc
@@ -27,6 +27,14 @@ MapTcpSocket::MapTcpSocket(NetworkBackendInterface* backend, uint32_t sip, uint3
 {
   fd_ = fd;
 
+  // SO_OOBINLINE
+  int flag_oob = 1;
+  MV_ASSERT(setsockopt(fd_, SOL_SOCKET, SO_OOBINLINE, &flag_oob, sizeof(flag_oob)) == 0);
+
+  // Disable Nagle's algorithm
+  int flag = 1;
+  MV_ASSERT(setsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) == 0);
+
   device_->StartPolling(fd_, EPOLLIN | EPOLLOUT | EPOLLET, [this](auto events) {
     can_read_ = events & EPOLLIN;
     can_write_ = events & EPOLLOUT;

--- a/networks/uip/redirect_tcp.cc
+++ b/networks/uip/redirect_tcp.cc
@@ -293,10 +293,6 @@ void RedirectTcpSocket::OnPacketFromGuest(Ipv4Packet* packet) {
 
   ack_host_ += packet->data_length;
 
-  if (can_write()) {
-    StartWriting();
-  }
-
   /* If seq host is equal to old, no data is read, but we need to send ACK
    * If no data length, this ack packet is not necessary, right?
    */
@@ -309,5 +305,9 @@ void RedirectTcpSocket::OnPacketFromGuest(Ipv4Packet* packet) {
     if (ack_packet) {
       OnDataFromHost(ack_packet, TCP_FLAG_ACK);
     }
+  }
+
+  if (can_write()) {
+    StartWriting();
   }
 }


### PR DESCRIPTION
1. RDP client packet delays because of the unimplemented TCP_PUSH flag. It is fixed now.
2. Disable Nagle for TCP connections.
3. Fix alt key problem after loading the snapshots.