### PR TITLE
optimize callback processing in DiskImage

### DIFF
--- a/devices/display/qxl/qxl.cc
+++ b/devices/display/qxl/qxl.cc
@@ -45,7 +45,7 @@ Qxl::Qxl() {
   pci_header_.subsys_id = 0x1100;
   
   /* Bar 0: 256MB VRAM */
-  vga_surface_size_ = _MB(16);
+  vga_surface_size_ = _MB(32);
   vram_size_ = _MB(256);
   SetupPciBar(0, vram_size_, kIoResourceTypeRam);
 

--- a/images/image.cc
+++ b/images/image.cc
@@ -76,16 +76,14 @@ void DiskImage::WorkerProcess() {
       break;
     }
 
-    auto& callback = worker_queue_.front();
+    std::swap(pending_callbacks_, worker_queue_);
     lock.unlock();
   
-    callback();
-
-    /* Only remove item after job is done.
-     * Remember to lock mutex again when operating on worker_queue_
-     */
-    lock.lock();
-    worker_queue_.pop_front();
+    // Execute all callbacks
+    for (auto& callback : pending_callbacks_) {
+      callback();
+    }
+    pending_callbacks_.clear();
   }
   
   io_->UnregisterDiskImage(this);

--- a/include/disk_image.h
+++ b/include/disk_image.h
@@ -23,7 +23,6 @@
 #include <functional>
 #include <thread>
 #include <mutex>
-#include <deque>
 #include <condition_variable>
 
 #include "utilities.h"
@@ -94,7 +93,8 @@ class DiskImage : public Object {
   std::thread               worker_thread_;
   std::mutex                worker_mutex_;
   std::condition_variable   worker_cv_;
-  std::deque<VoidCallback>  worker_queue_;
+  std::vector<VoidCallback> worker_queue_;
+  std::vector<VoidCallback> pending_callbacks_;
   bool                      finalized_ = false;
 
   void WorkerProcess();


### PR DESCRIPTION
1. optimize callback processing in DiskImage
2. increase vga surface size to 32MB for 3k screen resolution